### PR TITLE
Bumps dependency of flarum-ext-markdown to beta 5 so that no composer…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,8 @@
         "source": "https://github.com/flagrow/flarum-ext-image-upload"
     },
     "require": {
-        "flarum/core": "^0.1.0-beta.4",
-        "flarum/composer-installer": "^0.3.0",
-        "flarum/flarum-ext-markdown": "^0.1.0-beta.3"
+        "flarum/core": "^0.1.0-beta.5",
+        "flarum/flarum-ext-markdown": "^0.1.0-beta.5"
     },
     "suggest": {
         "cloudinary/cloudinary_php": "Allows uploading images to cloudinary."


### PR DESCRIPTION
… installer is created anymore

flarum-ext.-markdown beta 3 requires the composer installer which then destroys your installation because of creating a extension dir etc.
